### PR TITLE
Refactored to be slightly more idiomatic

### DIFF
--- a/src/gba.nims
+++ b/src/gba.nims
@@ -8,3 +8,5 @@ when defined(emscripten):
   --dynlibOverride:SDL2
 
   switch("passL", "-s WASM=1 -s USE_SDL=2 -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s EXPORTED_FUNCTIONS=_initFromEmscripten -s LINKABLE=1 -s EXPORT_ALL=1 -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 -O3 -o web/em.js --preload-file bios.bin")
+
+--experimental:"overloadableEnums"

--- a/src/gba/apu.nim
+++ b/src/gba/apu.nim
@@ -55,7 +55,7 @@ proc newAPU*(gba: GBA): APU =
 
 proc getSample(apu: APU): proc() = (proc() =
   apu.gba.scheduler.schedule(samplePeriod, apu.getSample(), EventType.apu)
-  let channel1Amp = cast[Channel1](apu.channel1).getAmplitude()
+  let channel1Amp = Channel1(apu.channel1).getAmplitude()
   bufferPos += 1
   resample.write(channel1Amp)
 
@@ -75,14 +75,8 @@ proc getSample(apu: APU): proc() = (proc() =
 proc tickFrameSequencer(apu: APU): proc() = (proc() =
   apu.gba.scheduler.schedule(frameSequencerPeriod, apu.tickFrameSequencer(), EventType.apu)
   case frameSequencerStage
-  of 0:
-    cast[Channel1](apu.channel1).lengthStep()
-  of 2:
-    cast[Channel1](apu.channel1).lengthStep()
-  of 4:
-    cast[Channel1](apu.channel1).lengthStep()
-  of 6:
-    cast[Channel1](apu.channel1).lengthStep()
+  of 0, 2, 4, 6:
+    Channel1(apu.channel1).lengthStep()
   else: discard
   frameSequencerStage = (frameSequencerStage + 1) and 7)
 

--- a/src/gba/dma.nim
+++ b/src/gba/dma.nim
@@ -42,12 +42,11 @@ proc trigger(gba: GBA, channel: SomeInteger) =
   if not dmacnt.repeat or dmacnt.timing == DmaStartTiming.immediate:
     dmacnt_h[channel].enable = false
   if dmacnt.irq:
-    case channel:
-    of 0: gba.interrupts.regIf.dma0 = true
-    of 1: gba.interrupts.regIf.dma1 = true
-    of 2: gba.interrupts.regIf.dma2 = true
-    of 3: gba.interrupts.regIf.dma3 = true
-    else: quit "Bad dma channel. Impossible case."
+    if channel in typeof(channel)(0)..typeof(channel)(3):
+      const dmaArr = [dma0, dma1, dma2, dma3]
+      gba.interrupts.regIf.incl dmaArr[channel]
+    else:
+      quit "Bad dma channel. Impossible case."
     gba.interrupts.scheduleCheck()
 
 proc `[]`*(dma: DMA, address: SomeInteger): uint8 =

--- a/src/gba/keypad.nim
+++ b/src/gba/keypad.nim
@@ -3,8 +3,9 @@ import sdl2
 import types, regs
 
 var
-  keyinput = cast[KEYINPUT](0xFFFF'u16)
+  keyinput = {KeyInput.low..KeyInput.high}
   keycnt = cast[KEYCNT](0xFFFF'u16)
+static: assert sizeof(KeyInputs) == sizeof(uint16)
 
 proc newKeypad*(gba: GBA): Keypad =
   new result
@@ -25,15 +26,15 @@ proc `[]=`*(keypad: Keypad, address: SomeInteger, value: uint8) =
 proc keyEvent*(keypad: Keypad, event: KeyboardEventObj) =
   let bit = not(bool(event.state))
   case event.keysym.scancode
-  of SDL_SCANCODE_E: keyinput.up = bit
-  of SDL_SCANCODE_D: keyinput.down = bit
-  of SDL_SCANCODE_S: keyinput.left = bit
-  of SDL_SCANCODE_F: keyinput.right = bit
-  of SDL_SCANCODE_W: keyinput.l = bit
-  of SDL_SCANCODE_R: keyinput.r = bit
-  of SDL_SCANCODE_J: keyinput.b = bit
-  of SDL_SCANCODE_K: keyinput.a = bit
-  of SDL_SCANCODE_L: keyinput.select = bit
-  of SDL_SCANCODE_SEMICOLON: keyinput.start = bit
+  of SDL_SCANCODE_E: keyinput.incl up
+  of SDL_SCANCODE_D: keyinput.incl down
+  of SDL_SCANCODE_S: keyinput.incl left
+  of SDL_SCANCODE_F: keyinput.incl right
+  of SDL_SCANCODE_W: keyinput.incl l
+  of SDL_SCANCODE_R: keyinput.incl r
+  of SDL_SCANCODE_J: keyinput.incl b
+  of SDL_SCANCODE_K: keyinput.incl a
+  of SDL_SCANCODE_L: keyinput.incl select
+  of SDL_SCANCODE_SEMICOLON: keyinput.incl start
   of SDL_SCANCODE_Q: quit "quit q"
   else: discard

--- a/src/gba/regs.nim
+++ b/src/gba/regs.nim
@@ -78,7 +78,7 @@ type
     objHSize* {.bitsize:4.}: cuint
     objVSize* {.bitsize:4.}: cuint
 
-  BLDCNT* {.packed.} = object
+  BLDCNT* {.packed.} = object # Probably can make a set aswell
     bg0First* {.bitsize:1.}: bool
     bg1First* {.bitsize:1.}: bool
     bg2First* {.bitsize:1.}: bool
@@ -127,54 +127,47 @@ type
     enable* {.bitsize:1.}: bool
     notUsed2* {.bitsize:8.}: cuint
 
-  KeypadRegs = KEYINPUT | KEYCNT
+  KeypadRegs = KeyInputs | KEYCNT
 
-  KEYINPUT* {.packed.} = object
-    a* {.bitsize:1.}: bool
-    b* {.bitsize:1.}: bool
-    select* {.bitsize:1.}: bool
-    start* {.bitsize:1.}: bool
-    right* {.bitsize:1.}: bool
-    left* {.bitsize:1.}: bool
-    up* {.bitsize:1.}: bool
-    down* {.bitsize:1.}: bool
-    r* {.bitsize:1.}: bool
-    l* {.bitsize:1.}: bool
-    notUsed* {.bitsize:6.}: cuint
+  KeyInput* = enum
+    a
+    b
+    select
+    start
+    right
+    left
+    up
+    down
+    r
+    l
+
+  KeyInputs* = set[KeyInput]
 
   KEYCNT* {.packed.} = object
-    a* {.bitsize:1.}: bool
-    b* {.bitsize:1.}: bool
-    select* {.bitsize:1.}: bool
-    start* {.bitsize:1.}: bool
-    right* {.bitsize:1.}: bool
-    left* {.bitsize:1.}: bool
-    up* {.bitsize:1.}: bool
-    down* {.bitsize:1.}: bool
-    r* {.bitsize:1.}: bool
-    l* {.bitsize:1.}: bool
+    inputs: KeyInputs
     notUsed* {.bitsize:4.}: cuint
     irqEnable* {.bitsize:1.}: bool
     irqCondition* {.bitsize:1.}: bool
 
-  MiscRegs = INTERRUPT | WAITCNT
+  MiscRegs = InterruptFlags | WAITCNT
 
-  INTERRUPT* {.packed.} = object
-    vblank* {.bitsize:1.}: bool
-    hblank* {.bitsize:1.}: bool
-    vcount* {.bitsize:1.}: bool
-    timer0* {.bitsize:1.}: bool
-    timer1* {.bitsize:1.}: bool
-    timer2* {.bitsize:1.}: bool
-    timer3* {.bitsize:1.}: bool
-    serial* {.bitsize:1.}: bool
-    dma0* {.bitsize:1.}: bool
-    dma1* {.bitsize:1.}: bool
-    dma2* {.bitsize:1.}: bool
-    dma3* {.bitsize:1.}: bool
-    keypad* {.bitsize:1.}: bool
-    gamepak* {.bitsize:1.}: bool
-    notUsed* {.bitsize:2.}: cuint
+  Interrupt* = enum
+    vblank
+    hblank
+    vcount
+    timer0
+    timer1
+    timer2
+    timer3
+    serial
+    dma0
+    dma1
+    dma2
+    dma3
+    keypad
+    gamepak
+
+  InterruptFlags* = set[Interrupt]
 
   WAITCNT* {.packed.} = object
     sramWaitControl* {.bitsize:2.}: cuint

--- a/src/gba/timer.nim
+++ b/src/gba/timer.nim
@@ -2,7 +2,7 @@ import types, interrupts, regs, scheduler
 
 const
   periods = [1'u16, 64, 256, 1024]
-  events = [timer0, timer1, timer2, timer3]
+  events = [EventType.timer0, timer1, timer2, timer3]
 
 var
   reload: array[4, uint16]
@@ -31,12 +31,11 @@ proc overflow(timer: Timer, num: SomeInteger): proc() = (proc() =
     if counter[num + 1] == 0: timer.overflowProcs[num + 1]()
   # todo: handle apu logic
   if tmcnt[num].irq:
-    case num:
-    of 0: timer.gba.interrupts.regIf.timer0 = true
-    of 1: timer.gba.interrupts.regIf.timer1 = true
-    of 2: timer.gba.interrupts.regIf.timer2 = true
-    of 3: timer.gba.interrupts.regIf.timer3 = true
-    else: quit "Bad timer number. Impossible case."
+    if num in typeof(num)(0)..typeof(num)(3):
+      const timers = [Interrupt.timer0, timer1, timer2, timer3]
+      timer.gba.interrupts.regIf.incl timers[num]
+    else:
+      quit "Bad timer number. Impossible case."
     timer.gba.interrupts.scheduleCheck()
   if not tmcnt[num].cascade:
     scheduleTimer(timer, num))

--- a/src/gba/types.nim
+++ b/src/gba/types.nim
@@ -58,8 +58,8 @@ type
   Interrupts* = ref object
     gba*: GBA
     ime*: bool
-    regIe*: INTERRUPT
-    regIf*: INTERRUPT
+    regIe*: InterruptFlags
+    regIf*: InterruptFlags
 
   Timer* = ref object
     gba*: GBA


### PR DESCRIPTION
Turned the few types that could be bitsets into bitsets which allows nicer written code. Enable overloadable enums for those new enums, replaced the scary `cast[Channel1](channel)` to `Channel1(channel)`, and also removed/replaced some redundant logic.